### PR TITLE
Inline Link and Image parsing

### DIFF
--- a/src/test_utils.py
+++ b/src/test_utils.py
@@ -1,13 +1,14 @@
 import unittest
 
-from textnode import TextNode, TextType
-from utils import (
+from src.textnode import TextNode, TextType
+from src.utils import (
     extract_markdown_images,
     extract_markdown_links,
     split_nodes_delimiter,
     split_nodes_image,
-    split_nodes_link
+    split_nodes_link,
 )
+
 
 class TestInlineMarkdown(unittest.TestCase):
     def test_code_case(self):
@@ -19,7 +20,7 @@ class TestInlineMarkdown(unittest.TestCase):
             TextNode(" word", TextType.TEXT),
         ]
         self.assertListEqual(new_nodes, expected)
-    
+
     def test_bold_case(self):
         node = TextNode("This is text with a **bold** word", TextType.TEXT)
         new_nodes = split_nodes_delimiter([node], "**", TextType.BOLD)
@@ -36,22 +37,24 @@ class TestInlineMarkdown(unittest.TestCase):
         expected = [
             TextNode("This is text with an ", TextType.TEXT),
             TextNode("italic", TextType.ITALIC),
-            TextNode(" word", TextType.TEXT)
+            TextNode(" word", TextType.TEXT),
         ]
         self.assertListEqual(new_nodes, expected)
 
     def test_multiple_italic_case(self):
-        node = TextNode("This is text with multiple _italic_ words. _Foo_ bar", TextType.TEXT)
+        node = TextNode(
+            "This is text with multiple _italic_ words. _Foo_ bar", TextType.TEXT
+        )
         new_nodes = split_nodes_delimiter([node], "_", TextType.ITALIC)
         expected = [
             TextNode("This is text with multiple ", TextType.TEXT),
             TextNode("italic", TextType.ITALIC),
             TextNode(" words. ", TextType.TEXT),
             TextNode("Foo", TextType.ITALIC),
-            TextNode(" bar", TextType.TEXT)
+            TextNode(" bar", TextType.TEXT),
         ]
         self.assertListEqual(new_nodes, expected)
-    
+
     def test_multi_word_bold_case(self):
         node = TextNode("This is text with a **very bold** word", TextType.TEXT)
         new_nodes = split_nodes_delimiter([node], "**", TextType.BOLD)
@@ -77,11 +80,9 @@ class TestInlineMarkdown(unittest.TestCase):
             ("obi wan", "https://i.imgur.com/fJRm4Vk.jpeg"),
         ]
         self.assertListEqual(matches, expected)
-    
+
     def test_extract_single_markdown_link(self):
-        matches = extract_markdown_links(
-            "This is text with a [link](https://foo.com)"
-        )
+        matches = extract_markdown_links("This is text with a [link](https://foo.com)")
         expected = [("link", "https://foo.com")]
         self.assertListEqual(matches, expected)
 
@@ -93,7 +94,7 @@ class TestInlineMarkdown(unittest.TestCase):
             ("to youtube", "https://www.youtube.com/@bootdotdev"),
         ]
         self.assertListEqual(matches, expected)
-    
+
     def test_split_images(self):
         node = TextNode(
             "This is text with an ![image](https://i.imgur.com/zjjcJKZ.png) and another ![second image](https://i.imgur.com/3elNhQu.png)",
@@ -111,7 +112,7 @@ class TestInlineMarkdown(unittest.TestCase):
             ],
             new_nodes,
         )
-    
+
     def test_split_images_end_text(self):
         node = TextNode(
             "This is text with an ![image](https://i.imgur.com/zjjcJKZ.png) called image",
@@ -140,10 +141,10 @@ class TestInlineMarkdown(unittest.TestCase):
             ],
             new_nodes,
         )
-    
+
     def test_split_links(self):
         node = TextNode(
-             "This is text with a link [to boot dev](https://www.boot.dev) and [to youtube](https://www.youtube.com/@bootdotdev)",
+            "This is text with a link [to boot dev](https://www.boot.dev) and [to youtube](https://www.youtube.com/@bootdotdev)",
             TextType.TEXT,
         )
         new_nodes = split_nodes_link([node])
@@ -156,9 +157,9 @@ class TestInlineMarkdown(unittest.TestCase):
                     "to youtube", TextType.LINK, "https://www.youtube.com/@bootdotdev"
                 ),
             ],
-            new_nodes
+            new_nodes,
         )
-    
+
     def test_split_links_start_text(self):
         node = TextNode(
             "[To boot dev](https://www.boot.dev) is the link",
@@ -172,7 +173,7 @@ class TestInlineMarkdown(unittest.TestCase):
             ],
             new_nodes,
         )
-    
+
     def test_split_links_end_text(self):
         node = TextNode(
             "This is text with a link [to boot dev](https://www.boot.dev) to learn back-end",
@@ -187,4 +188,3 @@ class TestInlineMarkdown(unittest.TestCase):
             ],
             new_nodes,
         )
-    

--- a/src/test_utils.py
+++ b/src/test_utils.py
@@ -5,6 +5,8 @@ from utils import (
     extract_markdown_images,
     extract_markdown_links,
     split_nodes_delimiter,
+    split_nodes_image,
+    split_nodes_link
 )
 
 class TestInlineMarkdown(unittest.TestCase):
@@ -60,8 +62,6 @@ class TestInlineMarkdown(unittest.TestCase):
         ]
         self.assertListEqual(new_nodes, expected)
 
-
-class TestExtractMarkdown(unittest.TestCase):
     def test_extract_single_markdown_image(self):
         matches = extract_markdown_images(
             "This is text with an ![image](https://i.imgur.com/zjjcJKZ.png)"
@@ -93,3 +93,98 @@ class TestExtractMarkdown(unittest.TestCase):
             ("to youtube", "https://www.youtube.com/@bootdotdev"),
         ]
         self.assertListEqual(matches, expected)
+    
+    def test_split_images(self):
+        node = TextNode(
+            "This is text with an ![image](https://i.imgur.com/zjjcJKZ.png) and another ![second image](https://i.imgur.com/3elNhQu.png)",
+            TextType.TEXT,
+        )
+        new_nodes = split_nodes_image([node])
+        self.assertListEqual(
+            [
+                TextNode("This is text with an ", TextType.TEXT),
+                TextNode("image", TextType.IMAGE, "https://i.imgur.com/zjjcJKZ.png"),
+                TextNode(" and another ", TextType.TEXT),
+                TextNode(
+                    "second image", TextType.IMAGE, "https://i.imgur.com/3elNhQu.png"
+                ),
+            ],
+            new_nodes,
+        )
+    
+    def test_split_images_end_text(self):
+        node = TextNode(
+            "This is text with an ![image](https://i.imgur.com/zjjcJKZ.png) called image",
+            TextType.TEXT,
+        )
+        new_nodes = split_nodes_image([node])
+        self.assertListEqual(
+            [
+                TextNode("This is text with an ", TextType.TEXT),
+                TextNode("image", TextType.IMAGE, "https://i.imgur.com/zjjcJKZ.png"),
+                TextNode(" called image", TextType.TEXT),
+            ],
+            new_nodes,
+        )
+
+    def test_split_images_start_text(self):
+        node = TextNode(
+            "![image](https://i.imgur.com/zjjcJKZ.png) is the image",
+            TextType.TEXT,
+        )
+        new_nodes = split_nodes_image([node])
+        self.assertListEqual(
+            [
+                TextNode("image", TextType.IMAGE, "https://i.imgur.com/zjjcJKZ.png"),
+                TextNode(" is the image", TextType.TEXT),
+            ],
+            new_nodes,
+        )
+    
+    def test_split_links(self):
+        node = TextNode(
+             "This is text with a link [to boot dev](https://www.boot.dev) and [to youtube](https://www.youtube.com/@bootdotdev)",
+            TextType.TEXT,
+        )
+        new_nodes = split_nodes_link([node])
+        self.assertListEqual(
+            [
+                TextNode("This is text with a link ", TextType.TEXT),
+                TextNode("to boot dev", TextType.LINK, "https://www.boot.dev"),
+                TextNode(" and ", TextType.TEXT),
+                TextNode(
+                    "to youtube", TextType.LINK, "https://www.youtube.com/@bootdotdev"
+                ),
+            ],
+            new_nodes
+        )
+    
+    def test_split_links_start_text(self):
+        node = TextNode(
+            "[To boot dev](https://www.boot.dev) is the link",
+            TextType.TEXT,
+        )
+        new_nodes = split_nodes_link([node])
+        self.assertListEqual(
+            [
+                TextNode("To boot dev", TextType.LINK, "https://www.boot.dev"),
+                TextNode(" is the link", TextType.TEXT),
+            ],
+            new_nodes,
+        )
+    
+    def test_split_links_end_text(self):
+        node = TextNode(
+            "This is text with a link [to boot dev](https://www.boot.dev) to learn back-end",
+            TextType.TEXT,
+        )
+        new_nodes = split_nodes_link([node])
+        self.assertListEqual(
+            [
+                TextNode("This is text with a link ", TextType.TEXT),
+                TextNode("to boot dev", TextType.LINK, "https://www.boot.dev"),
+                TextNode(" to learn back-end", TextType.TEXT),
+            ],
+            new_nodes,
+        )
+    

--- a/src/test_utils.py
+++ b/src/test_utils.py
@@ -1,7 +1,11 @@
 import unittest
 
 from textnode import TextNode, TextType
-from utils import split_nodes_delimiter
+from utils import (
+    extract_markdown_images,
+    extract_markdown_links,
+    split_nodes_delimiter,
+)
 
 class TestInlineMarkdown(unittest.TestCase):
     def test_code_case(self):
@@ -55,3 +59,37 @@ class TestInlineMarkdown(unittest.TestCase):
             TextNode(" word", TextType.TEXT),
         ]
         self.assertListEqual(new_nodes, expected)
+
+
+class TestExtractMarkdown(unittest.TestCase):
+    def test_extract_single_markdown_image(self):
+        matches = extract_markdown_images(
+            "This is text with an ![image](https://i.imgur.com/zjjcJKZ.png)"
+        )
+        expected = [("image", "https://i.imgur.com/zjjcJKZ.png")]
+        self.assertListEqual(matches, expected)
+
+    def test_extract_multiple_markdown_images(self):
+        text = "This is text with a ![rick roll](https://i.imgur.com/aKaOqIh.gif) and ![obi wan](https://i.imgur.com/fJRm4Vk.jpeg)"
+        matches = extract_markdown_images(text)
+        expected = [
+            ("rick roll", "https://i.imgur.com/aKaOqIh.gif"),
+            ("obi wan", "https://i.imgur.com/fJRm4Vk.jpeg"),
+        ]
+        self.assertListEqual(matches, expected)
+    
+    def test_extract_single_markdown_link(self):
+        matches = extract_markdown_links(
+            "This is text with a [link](https://foo.com)"
+        )
+        expected = [("link", "https://foo.com")]
+        self.assertListEqual(matches, expected)
+
+    def test_extract_multiple_markdown_links(self):
+        text = "This is text with a link [to boot dev](https://www.boot.dev) and [to youtube](https://www.youtube.com/@bootdotdev)"
+        matches = extract_markdown_links(text)
+        expected = [
+            ("to boot dev", "https://www.boot.dev"),
+            ("to youtube", "https://www.youtube.com/@bootdotdev"),
+        ]
+        self.assertListEqual(matches, expected)

--- a/src/utils.py
+++ b/src/utils.py
@@ -39,9 +39,21 @@ def extract_markdown_links(text: str) -> list[tuple]:
 def split_nodes_link(old_nodes: list[TextNode]) -> list[TextNode]:
     new_nodes = []
     for node in old_nodes:
-        if node.text_type != TextType.TEXT:
+        node_text = node.text
+        links = extract_markdown_links(node_text)
+        if not links or node.text_type != TextType.TEXT:
             new_nodes.append(node)
             continue
+
+        for link_text, link in links:
+            split_node_text = node_text.split(f"[{link_text}]({link})", 1)
+            if split_node_text[0]:
+                new_nodes.append(TextNode(split_node_text[0], TextType.TEXT))
+            new_nodes.append(TextNode(link_text, TextType.LINK, link))
+            node_text = split_node_text[1]
+        
+        if node_text:
+            new_nodes.append(TextNode(node_text, TextType.TEXT))
     
     return new_nodes
 
@@ -49,14 +61,21 @@ def split_nodes_link(old_nodes: list[TextNode]) -> list[TextNode]:
 def split_nodes_image(old_nodes: list[TextNode]) -> list[TextNode]:
     new_nodes = []
     for node in old_nodes:
-        images = extract_markdown_images(node.text)
+        node_text = node.text
+        images = extract_markdown_images(node_text)
         if not images or node.text_type != TextType.TEXT:
             new_nodes.append(node)
             continue
         
         for image_alt, image_link in images:
-            split_node_text = node.text.split(f"![{image_alt}]({image_link})", 1)
-            print(split_node_text)
+            split_node_text = node_text.split(f"![{image_alt}]({image_link})", 1)
+            if split_node_text[0]:
+                new_nodes.append(TextNode(split_node_text[0], TextType.TEXT))
+            new_nodes.append(TextNode(image_alt, TextType.IMAGE, image_link))
+            node_text = split_node_text[1]
+
+        if node_text:
+            new_nodes.append(TextNode(node_text, TextType.TEXT))
             
     
     return new_nodes

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from src.textnode import TextNode, TextType
 
 
@@ -21,4 +23,40 @@ def split_nodes_delimiter(
             else:
                 split_nodes.append(TextNode(text, text_type))
         new_nodes.extend(split_nodes)
+    return new_nodes
+
+
+def extract_markdown_images(text: str) -> list[tuple]:
+    img_regex = r"!\[([^\[\]]*)\]\(([^\(\)]*)\)"
+    return re.findall(img_regex, text)
+
+
+def extract_markdown_links(text: str) -> list[tuple]:
+    link_regex = r"(?<!!)\[([^\[\]]*)\]\(([^\(\)]*)\)"
+    return re.findall(link_regex, text)
+
+
+def split_nodes_link(old_nodes: list[TextNode]) -> list[TextNode]:
+    new_nodes = []
+    for node in old_nodes:
+        if node.text_type != TextType.TEXT:
+            new_nodes.append(node)
+            continue
+    
+    return new_nodes
+
+
+def split_nodes_image(old_nodes: list[TextNode]) -> list[TextNode]:
+    new_nodes = []
+    for node in old_nodes:
+        images = extract_markdown_images(node.text)
+        if not images or node.text_type != TextType.TEXT:
+            new_nodes.append(node)
+            continue
+        
+        for image_alt, image_link in images:
+            split_node_text = node.text.split(f"![{image_alt}]({image_link})", 1)
+            print(split_node_text)
+            
+    
     return new_nodes

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,7 +14,9 @@ def split_nodes_delimiter(
         split_nodes = []
         split_node_text = node.text.split(delimiter)
         if len(split_node_text) % 2 == 0:
-            raise Exception("Invalid Markdown syntax. Corresponding closing delimeter not detected.")
+            raise Exception(
+                "Invalid Markdown syntax. Corresponding closing delimeter not detected."
+            )
         for idx, text in enumerate(split_node_text):
             if text == "":
                 continue
@@ -51,10 +53,10 @@ def split_nodes_link(old_nodes: list[TextNode]) -> list[TextNode]:
                 new_nodes.append(TextNode(split_node_text[0], TextType.TEXT))
             new_nodes.append(TextNode(link_text, TextType.LINK, link))
             node_text = split_node_text[1]
-        
+
         if node_text:
             new_nodes.append(TextNode(node_text, TextType.TEXT))
-    
+
     return new_nodes
 
 
@@ -66,7 +68,7 @@ def split_nodes_image(old_nodes: list[TextNode]) -> list[TextNode]:
         if not images or node.text_type != TextType.TEXT:
             new_nodes.append(node)
             continue
-        
+
         for image_alt, image_link in images:
             split_node_text = node_text.split(f"![{image_alt}]({image_link})", 1)
             if split_node_text[0]:
@@ -76,6 +78,5 @@ def split_nodes_image(old_nodes: list[TextNode]) -> list[TextNode]:
 
         if node_text:
             new_nodes.append(TextNode(node_text, TextType.TEXT))
-            
-    
+
     return new_nodes


### PR DESCRIPTION
1. Adds regex matching to get markdown links and images
2. Implements splitting inline links and inline images into multiple TextNodes, of type `TEXT` and `LINK`, and `TEXT` and `IMAGE`, respectively