### PR TITLE
Block to html

### DIFF
--- a/src/block_markdown.py
+++ b/src/block_markdown.py
@@ -46,51 +46,92 @@ def block_to_block_type(text_block: str) -> BlockType:
     return BlockType.PARAGRAPH
 
 
+def markdown_to_html_node(markdown: str) -> HTMLNode:
+    blocks = markdown_to_blocks(markdown)
+    children = []
+    for block in blocks:
+        html_node = block_to_html_node(block)
+        children.append(html_node)
+
+    return ParentNode("div", children=children)
+
+
+def block_to_html_node(block: str) -> HTMLNode:
+    block_type = block_to_block_type(block)
+    if block_type == BlockType.PARAGRAPH:
+        return paragraph_to_html_node(block)
+    if block_type == BlockType.HEADING:
+        return heading_to_html_node(block)
+    if block_type == BlockType.CODE:
+        return code_to_html_node(block)
+    if block_type == BlockType.QUOTE:
+        return quote_to_html_node(block)
+    if block_type == BlockType.ULIST:
+        return ulist_to_html_node(block)
+    if block_type == BlockType.OLIST:
+        return olist_to_html_node(block)
+
+    raise ValueError("Invalid Block Type")
+
+
 def text_to_children(text: str) -> list[HTMLNode]:
     text_nodes = text_to_textnodes(text)
     return [text_node_to_html_node(tn) for tn in text_nodes]
 
 
-def markdown_to_html_node(markdown: str) -> HTMLNode:
-    blocks = markdown_to_blocks(markdown)
-    children = []
-    for block in blocks:
-        block_type = block_to_block_type(block)
+def paragraph_to_html_node(block: str) -> HTMLNode:
+    lines = block.split("\n")
+    paragraph = " ".join(lines)
+    return ParentNode("p", children=text_to_children(paragraph))
 
-        if block_type == BlockType.PARAGRAPH:
-            html_node = ParentNode(
-                "p", children=text_to_children(block.replace("\n", " "))
-            )
-        elif block_type == BlockType.HEADING:
-            header_num = block.count("#")
-            html_node = ParentNode(f"h{header_num}", children=text_to_children(block))
-        elif block_type == BlockType.CODE:
-            node = TextNode(block.replace("```", ""), TextType.CODE)
-            html_node = ParentNode("pre", children=[text_node_to_html_node(node)])
-        elif block_type == BlockType.QUOTE:
-            html_node = ParentNode(
-                "blockquote", children=text_to_children(block.replace(">", ""))
-            )
-        elif block_type == BlockType.ULIST:
-            children = []
-            for line in block.split("\n"):
-                child_node = ParentNode(
-                    "li", children=text_to_children(line.replace("- ", ""))
-                )
-                children.append(child_node)
-            html_node = ParentNode("ul", children=children)
-        elif block_type == BlockType.OLIST:
-            children = []
-            for line in block.split("\n"):
-                child_node = ParentNode(
-                    "li", children=text_to_children(line.split(". ", 1)[1])
-                )
-                children.append(child_node)
-            html_node = ParentNode("ol", children=children)
+
+def heading_to_html_node(block: str) -> HTMLNode:
+    level = 0
+    for char in block:
+        if char == "#":
+            level += 1
         else:
-            raise ValueError("Invalid Block Type")
+            break
+    if level + 1 >= len(block):
+        raise ValueError(f"invalid heading level: {level}")
+    header = block[level + 1 :]
+    return ParentNode(f"h{level}", children=text_to_children(header))
 
-        children.append(html_node)
 
-    parent_node = ParentNode("div", children=children)
-    return parent_node
+def code_to_html_node(block: str) -> HTMLNode:
+    if not block.startswith("```") or not block.endswith("```"):
+        raise ValueError("invalid code block")
+
+    raw_node = TextNode(block[4:-3], TextType.TEXT)
+    return ParentNode(
+        "pre",
+        children=[ParentNode("code", children=[text_node_to_html_node(raw_node)])],
+    )
+
+
+def quote_to_html_node(block: str) -> HTMLNode:
+    lines = block.split("\n")
+    new_lines = []
+    for line in lines:
+        if not line.startswith(">"):
+            raise ValueError("invalid quote block")
+
+        new_lines.append(line[2:])
+
+    return ParentNode("blockquote", children=text_to_children(" ".join(new_lines)))
+
+
+def ulist_to_html_node(block: str) -> HTMLNode:
+    items = block.split("\n")
+    html_items = [
+        ParentNode("li", children=text_to_children(item[2:])) for item in items
+    ]
+    return ParentNode("ul", children=html_items)
+
+
+def olist_to_html_node(block: str) -> HTMLNode:
+    items = block.split("\n")
+    html_items = [
+        ParentNode("li", children=text_to_children(item[3:])) for item in items
+    ]
+    return ParentNode("ol", children=html_items)

--- a/src/block_markdown.py
+++ b/src/block_markdown.py
@@ -1,5 +1,9 @@
 from enum import StrEnum
 
+from src.htmlnode import HTMLNode, ParentNode
+from src.inline_markdown import text_to_textnodes
+from src.textnode import TextNode, TextType, text_node_to_html_node
+
 
 class BlockType(StrEnum):
     PARAGRAPH = "paragraph"
@@ -40,3 +44,53 @@ def block_to_block_type(text_block: str) -> BlockType:
         return BlockType.OLIST
 
     return BlockType.PARAGRAPH
+
+
+def text_to_children(text: str) -> list[HTMLNode]:
+    text_nodes = text_to_textnodes(text)
+    return [text_node_to_html_node(tn) for tn in text_nodes]
+
+
+def markdown_to_html_node(markdown: str) -> HTMLNode:
+    blocks = markdown_to_blocks(markdown)
+    children = []
+    for block in blocks:
+        block_type = block_to_block_type(block)
+
+        if block_type == BlockType.PARAGRAPH:
+            html_node = ParentNode(
+                "p", children=text_to_children(block.replace("\n", " "))
+            )
+        elif block_type == BlockType.HEADING:
+            header_num = block.count("#")
+            html_node = ParentNode(f"h{header_num}", children=text_to_children(block))
+        elif block_type == BlockType.CODE:
+            node = TextNode(block.replace("```", ""), TextType.CODE)
+            html_node = ParentNode("pre", children=[text_node_to_html_node(node)])
+        elif block_type == BlockType.QUOTE:
+            html_node = ParentNode(
+                "blockquote", children=text_to_children(block.replace(">", ""))
+            )
+        elif block_type == BlockType.ULIST:
+            children = []
+            for line in block.split("\n"):
+                child_node = ParentNode(
+                    "li", children=text_to_children(line.replace("- ", ""))
+                )
+                children.append(child_node)
+            html_node = ParentNode("ul", children=children)
+        elif block_type == BlockType.OLIST:
+            children = []
+            for line in block.split("\n"):
+                child_node = ParentNode(
+                    "li", children=text_to_children(line.split(". ", 1)[1])
+                )
+                children.append(child_node)
+            html_node = ParentNode("ol", children=children)
+        else:
+            raise ValueError("Invalid Block Type")
+
+        children.append(html_node)
+
+    parent_node = ParentNode("div", children=children)
+    return parent_node

--- a/src/test_block_markdown.py
+++ b/src/test_block_markdown.py
@@ -90,6 +90,21 @@ This is the same paragraph on a new line
         block_type = block_to_block_type(block)
         self.assertEqual(block_type, BlockType.OLIST)
 
+    def test_paragraph(self):
+        md = """
+This is **bolded** paragraph
+text in a p
+tag here
+
+"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><p>This is <b>bolded</b> paragraph text in a p tag here</p></div>",
+        )
+
     def test_paragraphs(self):
         md = """
 This is **bolded** paragraph
@@ -111,15 +126,66 @@ This is another paragraph with _italic_ text and `code` here
     def test_codeblock(self):
         md = """
 ```
-This is text that _should_ remain
-the **same** even with inline stuff
+HTML is _not_ real code
+Brainfuck is **real** code
 ```
 """
         node = markdown_to_html_node(md)
         html = node.to_html()
         self.assertEqual(
             html,
-            "<div><pre><code>\nThis is text that _should_ remain\nthe **same** even with inline stuff\n</code></pre></div>",
+            "<div><pre><code>HTML is _not_ real code\nBrainfuck is **real** code\n</code></pre></div>",
+        )
+
+    def test_lists(self):
+        md = """
+- This is a list
+- with 3 items
+- and **more** items
+
+1. This is an `ordered` list
+2. with 3 items
+3. and more items
+
+"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><ul><li>This is a list</li><li>with 3 items</li><li>and <b>more</b> items</li></ul><ol><li>This is an <code>ordered</code> list</li><li>with 3 items</li><li>and more items</li></ol></div>",
+        )
+
+    def test_headings(self):
+        md = """
+# this is an h1
+
+this is some other text
+
+##### this is an h5
+"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><h1>this is an h1</h1><p>this is some other text</p><h5>this is an h5</h5></div>",
+        )
+
+    def test_blockquote(self):
+        md = """
+> This is a
+> blockquote block
+
+plus some other text
+
+"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><blockquote>This is a blockquote block</blockquote><p>plus some other text</p></div>",
         )
 
 

--- a/src/test_block_markdown.py
+++ b/src/test_block_markdown.py
@@ -1,6 +1,11 @@
 import unittest
 
-from src.block_markdown import BlockType, block_to_block_type, markdown_to_blocks
+from src.block_markdown import (
+    BlockType,
+    block_to_block_type,
+    markdown_to_blocks,
+    markdown_to_html_node,
+)
 
 
 class TestBlockMarkdown(unittest.TestCase):
@@ -84,6 +89,38 @@ This is the same paragraph on a new line
         block = "1. This is\n2. a list\n3. that is\n4. ordered"
         block_type = block_to_block_type(block)
         self.assertEqual(block_type, BlockType.OLIST)
+
+    def test_paragraphs(self):
+        md = """
+This is **bolded** paragraph
+text in a p
+tag here
+
+This is another paragraph with _italic_ text and `code` here
+
+"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        print(html)
+        self.assertEqual(
+            html,
+            "<div><p>This is <b>bolded</b> paragraph text in a p tag here</p><p>This is another paragraph with <i>italic</i> text and <code>code</code> here</p></div>",
+        )
+
+    def test_codeblock(self):
+        md = """
+```
+This is text that _should_ remain
+the **same** even with inline stuff
+```
+"""
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><pre><code>\nThis is text that _should_ remain\nthe **same** even with inline stuff\n</code></pre></div>",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Implements `markdown_to_html_node()`, that takes a markdown block and converts it into a single `HTMLNode`, with children broken down to the inline `LeafNode`
2. Adds a few helper functions to keep the code clean
3. Lots of tests