### PR TITLE
Implement Page Generation

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,46 @@
+# Tolkien Fan Club
+
+![JRR Tolkien sitting](/images/tolkien.png)
+
+Here's the deal, **I like Tolkien**.
+
+> "I am in fact a Hobbit in all but size."
+>
+> -- J.R.R. Tolkien
+
+## Blog posts
+
+- [Why Glorfindel is More Impressive than Legolas](/blog/glorfindel)
+- [Why Tom Bombadil Was a Mistake](/blog/tom)
+- [The Unparalleled Majesty of "The Lord of the Rings"](/blog/majesty)
+
+## Reasons I like Tolkien
+
+- You can spend years studying the legendarium and still not understand its depths
+- It can be enjoyed by children and adults alike
+- Disney _didn't ruin it_ (okay, but Amazon might have)
+- It created an entirely new genre of fantasy
+
+## My favorite characters (in order)
+
+1. Gandalf
+2. Bilbo
+3. Sam
+4. Glorfindel
+5. Galadriel
+6. Elrond
+7. Thorin
+8. Sauron
+9. Aragorn
+
+Here's what `elflang` looks like (the perfect coding language):
+
+```
+func main(){
+    fmt.Println("Aiya, Ambar!")
+}
+```
+
+Want to get in touch? [Contact me here](/contact).
+
+This site was generated with a custom-built [static site generator](https://www.boot.dev/courses/build-static-site-generator-python) from the course on [Boot.dev](https://www.boot.dev).

--- a/main.sh
+++ b/main.sh
@@ -1,1 +1,2 @@
 python3 -m src.main
+cd public && python3 -m http.server 8888

--- a/src/htmlnode.py
+++ b/src/htmlnode.py
@@ -29,7 +29,8 @@ class LeafNode(HTMLNode):
         super().__init__(tag=tag, value=value, children=None, props=props)
 
     def to_html(self) -> str:
-        if not self.value:
+        print(self.value)
+        if self.value is None:
             raise ValueError("LeafNode must have a value to convert to HTML")
 
         if not self.tag:

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,24 @@
 import os
 import shutil
 
+from src.page_gen import generate_page
 
 STATIC_PATH = "./static"
 PUBLIC_PATH = "./public"
+CONTENT_PATH = "./content"
+TEMPLATE_PATH = "./template.html"
 
 
 def main():
     print("Copying static files to public directory...")
     copy_dir("./static", "./public")
+
+    print("Generating page...")
+    generate_page(
+        os.path.join(CONTENT_PATH, "index.md"),
+        TEMPLATE_PATH,
+        os.path.join(PUBLIC_PATH, "index.html"),
+    )
     print("Done!")
 
 

--- a/src/page_gen.py
+++ b/src/page_gen.py
@@ -1,0 +1,32 @@
+import os
+
+from src.block_markdown import markdown_to_html_node
+
+
+def extract_title(markdown: str) -> str:
+    lines = markdown.split("\n")
+    for line in lines:
+        if line.startswith("# "):
+            return line[2:]
+
+    raise ValueError("Provided Markdown does not contain h1 header")
+
+
+def generate_page(from_path: str, template_path: str, dest_path: str) -> None:
+    print(f"Generating page from {from_path} to {dest_path} using {template_path}")
+    with open(from_path, "r", encoding="utf-8") as md_f:
+        md = md_f.read()
+
+    with open(template_path, "r", encoding="utf-8") as tf:
+        template = tf.read()
+
+    html_string = markdown_to_html_node(md).to_html()
+    title = extract_title(md)
+    html = template.replace("{{ Title }}", title).replace("{{ Content }}", html_string)
+
+    dest_dir = os.path.dirname(dest_path)
+    if dest_dir != "":
+        os.makedirs(dest_dir, exist_ok=True)
+
+    with open(dest_path, "w", encoding="utf-8") as w_f:
+        w_f.write(html)

--- a/src/tests/test_page_gen.py
+++ b/src/tests/test_page_gen.py
@@ -1,0 +1,35 @@
+import unittest
+
+from src.page_gen import extract_title
+
+
+class TestExtractTitle(unittest.TestCase):
+    def test_extract_title(self):
+        md = "# Header1"
+        title = extract_title(md)
+        expected = "Header1"
+        self.assertEqual(expected, title)
+
+    def test_extract_title_blocks(self):
+        md = """
+This is a paragraph
+
+## This is wrong header
+# This is correct header
+"""
+        title = extract_title(md)
+        expected = "This is correct header"
+        self.assertEqual(title, expected)
+
+    def test_extract_title_no_header(self):
+        md = """
+This is text that has no header
+
+foo
+"""
+        with self.assertRaises(ValueError):
+            extract_title(md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/template.html
+++ b/template.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ Title }}</title>
+    <link href="/index.css" rel="stylesheet" />
+  </head>
+
+  <body>
+    <article>{{ Content }}</article>
+  </body>
+</html>


### PR DESCRIPTION
1. Adds `generate_page()`, which takes a markdown file, an HTML template file, and a destination html file, and places the html generated from the markdown into the template, and writes the new HTML file to the destination.
2. Adds `extract_title()`, which takes a markdown string and looks for an `h1` header. Throws an exception if one isn't found.
3. Fixes a bug in HTMLNode where `.to_html()` fails if the value is `""`.
4. Tests
5. Updates `./main.sh` to run the website