### PR TITLE
implement recursive page gen

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,4 @@
-import os
-import shutil
-
-from src.page_gen import generate_page
+from src import page_gen
 
 STATIC_PATH = "./static"
 PUBLIC_PATH = "./public"
@@ -11,30 +8,11 @@ TEMPLATE_PATH = "./template.html"
 
 def main():
     print("Copying static files to public directory...")
-    copy_dir(STATIC_PATH, PUBLIC_PATH)
+    page_gen.copy_dir(STATIC_PATH, PUBLIC_PATH)
 
-    print("Generating page...")
-    generate_page(
-        os.path.join(CONTENT_PATH, "index.md"),
-        TEMPLATE_PATH,
-        os.path.join(PUBLIC_PATH, "index.html"),
-    )
+    print("Generating content...")
+    page_gen.generate_pages_recursive(CONTENT_PATH, TEMPLATE_PATH, PUBLIC_PATH)
     print("Done!")
-
-
-def copy_dir(src_dir: str, dest_dir: str) -> None:
-    if os.path.exists(dest_dir):
-        shutil.rmtree(dest_dir)
-    os.mkdir(dest_dir)
-
-    for item in os.listdir(src_dir):
-        src_path = os.path.join(src_dir, item)
-        dest_path = os.path.join(dest_dir, item)
-        print(f" * {src_path} -> {dest_path}")
-        if os.path.isfile(src_path):
-            shutil.copy(src_path, dest_path)
-        else:
-            copy_dir(src_path, dest_path)
 
 
 if __name__ == "__main__":

--- a/src/page_gen.py
+++ b/src/page_gen.py
@@ -1,6 +1,23 @@
 import os
+import shutil
+from pathlib import Path
 
 from src.block_markdown import markdown_to_html_node
+
+
+def copy_dir(src_dir: str, dest_dir: str) -> None:
+    if os.path.exists(dest_dir):
+        shutil.rmtree(dest_dir)
+    os.mkdir(dest_dir)
+
+    for item in os.listdir(src_dir):
+        src_path = os.path.join(src_dir, item)
+        dest_path = os.path.join(dest_dir, item)
+        print(f" * {src_path} -> {dest_path}")
+        if os.path.isfile(src_path):
+            shutil.copy(src_path, dest_path)
+        else:
+            copy_dir(src_path, dest_path)
 
 
 def extract_title(markdown: str) -> str:
@@ -30,3 +47,20 @@ def generate_page(from_path: str, template_path: str, dest_path: str) -> None:
 
     with open(dest_path, "w", encoding="utf-8") as w_f:
         w_f.write(html)
+
+
+def generate_pages_recursive(
+    dir_path_content: str, template_path: str, dest_dir_path: str
+) -> None:
+    contents = os.listdir(dir_path_content)
+    for item in contents:
+        next_path_content = os.path.join(dir_path_content, item)
+        next_dest_path = os.path.join(dest_dir_path, item)
+        if os.path.isfile(next_path_content):
+            next_dest_path = Path(next_dest_path).with_suffix(".html")
+            generate_page(next_path_content, template_path, next_dest_path)
+        else:
+            # print(f"Moving to next dir: {next_path_content}, {next_dest_path}")
+            generate_pages_recursive(
+                next_path_content, template_path, next_dest_path
+            )

--- a/src/page_gen.py
+++ b/src/page_gen.py
@@ -61,6 +61,4 @@ def generate_pages_recursive(
             generate_page(next_path_content, template_path, next_dest_path)
         else:
             # print(f"Moving to next dir: {next_path_content}, {next_dest_path}")
-            generate_pages_recursive(
-                next_path_content, template_path, next_dest_path
-            )
+            generate_pages_recursive(next_path_content, template_path, next_dest_path)


### PR DESCRIPTION
1. Adds `generate_pages_recursive()` function to generate multiple pages given a source directory, destination directory, and a template file
2. Moves `copy_dir()` from main.py to page_gen.py to improve maintainability
3. Update main to use new recursive function